### PR TITLE
Add DevAddr() method to Physical payload

### DIFF
--- a/phypayload.go
+++ b/phypayload.go
@@ -290,7 +290,12 @@ func (p PHYPayload) ValidateMIC(key AES128Key) (bool, error) {
 
 // DevAddr returns a device address (if any) associated to payload
 func (p PHYPayload) DevAddr() (*DevAddr, error) {
-	return nil, nil
+	macpayload, ok := p.MACPayload.(*MACPayload)
+	if !ok {
+		return nil, errors.New("lorawan: unable to get address of a join message")
+	}
+
+	return &macpayload.FHDR.DevAddr, nil
 }
 
 // EncryptMACPayload encrypts the MACPayload with the given key. Note that this

--- a/phypayload.go
+++ b/phypayload.go
@@ -289,13 +289,17 @@ func (p PHYPayload) ValidateMIC(key AES128Key) (bool, error) {
 }
 
 // DevAddr returns a device address (if any) associated to payload
-func (p PHYPayload) DevAddr() (*DevAddr, error) {
-	macpayload, ok := p.MACPayload.(*MACPayload)
-	if !ok {
-		return nil, errors.New("lorawan: unable to get address of a join message")
+func (p PHYPayload) DevAddr() (DevAddr, error) {
+	if p.MACPayload == nil {
+		return DevAddr{}, errors.New("lorawan: MACPayload should not be empty")
 	}
 
-	return &macpayload.FHDR.DevAddr, nil
+	macpayload, ok := p.MACPayload.(*MACPayload)
+	if !ok {
+		return DevAddr{}, errors.New("lorawan: unable to get address of a join message")
+	}
+
+	return macpayload.FHDR.DevAddr, nil
 }
 
 // EncryptMACPayload encrypts the MACPayload with the given key. Note that this

--- a/phypayload.go
+++ b/phypayload.go
@@ -288,6 +288,11 @@ func (p PHYPayload) ValidateMIC(key AES128Key) (bool, error) {
 	return true, nil
 }
 
+// DevAddr returns a device address (if any) associated to payload
+func (p PHYPayload) DevAddr() (*DevAddr, error) {
+	return nil, nil
+}
+
 // EncryptMACPayload encrypts the MACPayload with the given key. Note that this
 // should only be done when the MACPayload is a JoinAcceptPayload.
 // Note that the encryption should be performed after SetMIC since the MIC

--- a/phypayload_test.go
+++ b/phypayload_test.go
@@ -80,7 +80,7 @@ func TestPHYPayloadData(t *testing.T) {
 				Convey("Then one can get the corresponding device address", func() {
 					devAddr, err := phy.DevAddr()
 					So(err, ShouldBeNil)
-					So(*devAddr, ShouldResemble, DevAddr([4]byte{1, 2, 3, 4}))
+					So(devAddr, ShouldResemble, DevAddr([4]byte{1, 2, 3, 4}))
 				})
 
 				Convey("Then decrypting the FRMPayload does not error", func() {
@@ -140,8 +140,7 @@ func TestPHYPayloadJoinRequest(t *testing.T) {
 			})
 
 			Convey("Then no device address is associated", func() {
-				devAddr, err := phy.DevAddr()
-				So(devAddr, ShouldBeNil)
+				_, err := phy.DevAddr()
 				So(err, ShouldResemble, errors.New("lorawan: unable to get address of a join message"))
 			})
 

--- a/phypayload_test.go
+++ b/phypayload_test.go
@@ -2,6 +2,7 @@ package lorawan
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -76,6 +77,12 @@ func TestPHYPayloadData(t *testing.T) {
 					})
 				})
 
+				Convey("Then one can get the corresponding device address", func() {
+					devAddr, err := phy.DevAddr()
+					So(err, ShouldBeNil)
+					So(*devAddr, ShouldResemble, DevAddr([4]byte{1, 2, 3, 4}))
+				})
+
 				Convey("Then decrypting the FRMPayload does not error", func() {
 					appSKey := [16]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
 					So(macPl.DecryptFRMPayload(appSKey), ShouldBeNil)
@@ -130,6 +137,12 @@ func TestPHYPayloadJoinRequest(t *testing.T) {
 			Convey("Then the MHDR contains the expected data", func() {
 				So(phy.MHDR.MType, ShouldEqual, JoinRequest)
 				So(phy.MHDR.Major, ShouldEqual, LoRaWANR1)
+			})
+
+			Convey("Then no device address is associated", func() {
+				devAddr, err := phy.DevAddr()
+				So(devAddr, ShouldBeNil)
+				So(err, ShouldResemble, errors.New("lorawan: unable to get address of a join message"))
 			})
 
 			Convey("Then the MIC is valid", func() {


### PR DESCRIPTION
Hey !
I've added a little accessor to retrieve the Device Address from a given physical payload. It fails for join request / response messages as no address it defined at that moment.