### PR TITLE
Fix issue with MACPayload unmarshalling

### DIFF
--- a/macpayload.go
+++ b/macpayload.go
@@ -50,6 +50,7 @@ func (p *MACPayload) unmarshalPayload(data []byte) error {
 	if p.FPort == 0 {
 		// payload contains MAC commands
 		var pLen int
+		p.FRMPayload = make([]Payload, 0)
 		for i := 0; i < len(data); i++ {
 			if _, s, err := getMACPayloadAndSize(p.uplink, cid(data[i])); err != nil {
 				pLen = 0


### PR DESCRIPTION
Hey !

I stumbled across some troubles while trying to decrypt a payload holding MAC commands. Decrypted subsequent payloads were actually appended to the existing encrypted payloads. 
I've added some tests and merely add a line to reset the FRMPayload slice when unmarshalling.

Cheers.