### PR TITLE
Typo of DR0 in the US902_928 band

### DIFF
--- a/band/band_us902_928.go
+++ b/band/band_us902_928.go
@@ -38,7 +38,7 @@ const Name = "US 902-928"
 
 // DataRateConfiguration defines the available data rates
 var DataRateConfiguration = [...]DataRate{
-	{Modulation: LoRaModulation, SpreadFactor: 12, Bandwidth: 125},
+	{Modulation: LoRaModulation, SpreadFactor: 10, Bandwidth: 125},
 	{Modulation: LoRaModulation, SpreadFactor: 9, Bandwidth: 125},
 	{Modulation: LoRaModulation, SpreadFactor: 8, Bandwidth: 125},
 	{Modulation: LoRaModulation, SpreadFactor: 7, Bandwidth: 125},


### PR DESCRIPTION
DR0 should be **SF10** BW125 instead of **SF12** BW125.