### PR TITLE
Add support for Russia 864.0-865.0 and 868.7-892.2 as specified in LoRaWAN draft

### DIFF
--- a/band/band.go
+++ b/band/band.go
@@ -25,6 +25,7 @@ const (
 	IN_865_867 Name = "IN_865_867"
 	KR_920_923 Name = "KR_920_923"
 	US_902_928 Name = "US_902_928"
+	RU_864_869 Name = "RU_864_869"
 )
 
 // Modulation defines the modulation type.
@@ -470,6 +471,8 @@ func GetConfig(name Name, repeaterCompatible bool, dt lorawan.DwellTime) (Band, 
 		return newKR920Band()
 	case US_902_928:
 		return newUS902Band(repeaterCompatible)
+	case RU_864_869:
+		return newRU864Band(repeaterCompatible)
 	default:
 		return Band{}, fmt.Errorf("lorawan/band: band %s is undefined", name)
 	}

--- a/band/band_ru864_869.go
+++ b/band/band_ru864_869.go
@@ -1,0 +1,101 @@
+package band
+
+import "time"
+
+func newRU864Band(repeaterCompatible bool) (Band, error) {
+	var maxPayloadSize []MaxPayloadSize
+
+	if repeaterCompatible {
+		maxPayloadSize = []MaxPayloadSize{
+			{M: 59, N: 51},
+			{M: 59, N: 51},
+			{M: 59, N: 51},
+			{M: 123, N: 115},
+			{M: 230, N: 222},
+			{M: 230, N: 222},
+			{M: 230, N: 222},
+			{M: 230, N: 222},
+		}
+	} else {
+		maxPayloadSize = []MaxPayloadSize{
+			{M: 59, N: 51},
+			{M: 59, N: 51},
+			{M: 59, N: 51},
+			{M: 123, N: 115},
+			{M: 250, N: 242},
+			{M: 250, N: 242},
+			{M: 250, N: 242},
+			{M: 250, N: 242},
+		}
+	}
+
+	return Band{
+		DefaultTXPower:   14,
+		ImplementsCFlist: true,
+		RX2Frequency:     869100000,
+		RX2DataRate:      0,
+
+		MaxFCntGap:       16384,
+		ADRACKLimit:      64,
+		ADRACKDelay:      32,
+		ReceiveDelay1:    time.Second,
+		ReceiveDelay2:    time.Second * 2,
+		JoinAcceptDelay1: time.Second * 5,
+		JoinAcceptDelay2: time.Second * 6,
+		ACKTimeoutMin:    time.Second,
+		ACKTimeoutMax:    time.Second * 3,
+
+		DataRates: []DataRate{
+			{Modulation: LoRaModulation, SpreadFactor: 12, Bandwidth: 125},
+			{Modulation: LoRaModulation, SpreadFactor: 11, Bandwidth: 125},
+			{Modulation: LoRaModulation, SpreadFactor: 10, Bandwidth: 125},
+			{Modulation: LoRaModulation, SpreadFactor: 9, Bandwidth: 125},
+			{Modulation: LoRaModulation, SpreadFactor: 8, Bandwidth: 125},
+			{Modulation: LoRaModulation, SpreadFactor: 7, Bandwidth: 125},
+			{Modulation: LoRaModulation, SpreadFactor: 7, Bandwidth: 250},
+			{Modulation: FSKModulation, BitRate: 50000},
+		},
+
+		MaxPayloadSize: maxPayloadSize,
+
+		rx1DataRate: [][]int{
+			{0, 0, 0, 0, 0, 0},
+			{1, 0, 0, 0, 0, 0},
+			{2, 1, 0, 0, 0, 0},
+			{3, 2, 1, 0, 0, 0},
+			{4, 3, 2, 1, 0, 0},
+			{5, 4, 3, 2, 1, 0},
+			{6, 5, 4, 3, 2, 1},
+			{7, 6, 5, 4, 3, 2},
+		},
+
+		TXPowerOffset: []int{
+			0,
+			-2,
+			-4,
+			-6,
+			-8,
+			-10,
+			-12,
+			-14,
+		},
+
+		UplinkChannels: []Channel{
+			{Frequency: 868900000, DataRates: []int{0, 1, 2, 3, 4, 5}},
+			{Frequency: 869100000, DataRates: []int{0, 1, 2, 3, 4, 5}},
+		},
+
+		DownlinkChannels: []Channel{
+			{Frequency: 868900000, DataRates: []int{0, 1, 2, 3, 4, 5}},
+			{Frequency: 869100000, DataRates: []int{0, 1, 2, 3, 4, 5}},
+		},
+
+		getRX1ChannelFunc: func(txChannel int) int {
+			return txChannel
+		},
+
+		getRX1FrequencyFunc: func(b *Band, txFrequency int) (int, error) {
+			return txFrequency, nil
+		},
+	}, nil
+}

--- a/band/band_ru864_869_test.go
+++ b/band/band_ru864_869_test.go
@@ -1,0 +1,144 @@
+package band
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/brocaar/lorawan"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestRU864Band(t *testing.T) {
+	Convey("Given the RU 864-869 band is selected", t, func() {
+		band, err := GetConfig(RU_864_869, true, lorawan.DwellTimeNoLimit)
+		So(err, ShouldBeNil)
+
+		Convey("Then GetRX1Channel returns the uplink channel", func() {
+			for i := 0; i < 3; i++ {
+				rx1Chan := band.GetRX1Channel(i)
+				So(rx1Chan, ShouldEqual, i)
+			}
+		})
+
+		Convey("Then GetRX1Frequency returns the uplink frequency", func() {
+			for _, f := range []int{868900000, 869100000} {
+				freq, err := band.GetRX1Frequency(f)
+				So(err, ShouldBeNil)
+				So(freq, ShouldEqual, f)
+			}
+		})
+
+		Convey("Given five extra channels", func() {
+			chans := []int{
+				864100000,
+				864300000,
+				864500000,
+				864700000,
+				864900000,
+			}
+
+			for _, c := range chans {
+				band.AddChannel(c)
+			}
+
+			Convey("When testing GetLinkADRReqPayloadsForEnabledChannels", func() {
+				tests := []struct {
+					Name                       string
+					NodeChannels               []int
+					DisabledChannels           []int
+					ExpectedUplinkChannels     []int
+					ExpectedLinkADRReqPayloads []lorawan.LinkADRReqPayload
+				}{
+					{
+						Name:                   "no active node channels",
+						NodeChannels:           []int{},
+						ExpectedUplinkChannels: []int{0, 1},
+						ExpectedLinkADRReqPayloads: []lorawan.LinkADRReqPayload{
+							{
+								ChMask: lorawan.ChMask{true, true},
+							},
+						},
+						// we only activate the base channels
+					},
+					{
+						Name:                   "base channels are active",
+						NodeChannels:           []int{0, 1},
+						ExpectedUplinkChannels: []int{0, 1},
+						// we do not activate the CFList channels as we don't
+						// now if the node knows about these frequencies
+					},
+					{
+						Name:                   "base channels + two CFList channels are active",
+						NodeChannels:           []int{0, 1, 2, 3},
+						ExpectedUplinkChannels: []int{0, 1, 2, 3},
+						// we do not activate the CFList channels as we don't
+						// now if the node knows about these frequencies
+					},
+					{
+						Name:                   "base channels + CFList are active",
+						NodeChannels:           []int{0, 1, 2, 3, 4, 5, 6},
+						ExpectedUplinkChannels: []int{0, 1, 2, 3, 4, 5, 6},
+						// nothing to do, network and node are in sync
+					},
+					{
+						Name:                   "base channels + CFList are active on node, but CFList channels are disabled on the network",
+						NodeChannels:           []int{0, 1, 2, 3, 4, 5, 6},
+						DisabledChannels:       []int{2, 3, 4, 5, 6},
+						ExpectedUplinkChannels: []int{0, 1},
+						ExpectedLinkADRReqPayloads: []lorawan.LinkADRReqPayload{
+							{
+								ChMask: lorawan.ChMask{true, true},
+							},
+						},
+						// we disable the CFList channels as they became inactive
+					},
+				}
+
+				for i, test := range tests {
+					Convey(fmt.Sprintf("testing %s [%d]", test.Name, i), func() {
+						for _, c := range test.DisabledChannels {
+							So(band.DisableUplinkChannel(c), ShouldBeNil)
+						}
+						pls := band.GetLinkADRReqPayloadsForEnabledChannels(test.NodeChannels)
+						So(pls, ShouldResemble, test.ExpectedLinkADRReqPayloads)
+
+						chans, err := band.GetEnabledChannelsForLinkADRReqPayloads(test.NodeChannels, pls)
+						So(err, ShouldBeNil)
+						So(chans, ShouldResemble, test.ExpectedUplinkChannels)
+					})
+				}
+
+			})
+
+			Convey("Then GetChannel takes the extra channels into consideration", func() {
+				tests := []int{
+					868900000,
+					869100000,
+					864100000,
+					864300000,
+					864500000,
+					864700000,
+					864900000,
+				}
+
+				for expChannel, expFreq := range tests {
+					channel, err := band.GetUplinkChannelNumber(expFreq)
+					So(err, ShouldBeNil)
+					So(channel, ShouldEqual, expChannel)
+				}
+			})
+
+			Convey("Then GetCFList returns the expected CFList", func() {
+				cFList := band.GetCFList()
+				So(cFList, ShouldNotBeNil)
+				So(*cFList, ShouldEqual, lorawan.CFList{
+					864100000,
+					864300000,
+					864500000,
+					864700000,
+					864900000,
+				})
+			})
+		})
+	})
+}


### PR DESCRIPTION
This pull request adds support for Russian LoRaWAN frequencies which are now in draft state and are to be added to LoRaWAN regional parameters soon. Attached is the official IOTAS letter to LoRa Alliance with this frequency plan specification.

[iotas2loraaliance.pdf](https://github.com/brocaar/lorawan/files/1667873/iotas2loraaliance.pdf)
