### PR TITLE
Change AU915 DownlinkTXPower to 27

### DIFF
--- a/band/band_au915_928.go
+++ b/band/band_au915_928.go
@@ -26,7 +26,7 @@ func (b *au915Band) GetDefaults() Defaults {
 }
 
 func (b *au915Band) GetDownlinkTXPower(freq int) int {
-	return 20
+	return 27
 }
 
 func (b *au915Band) GetPingSlotFrequency(devAddr lorawan.DevAddr, beaconTime time.Duration) (int, error) {

--- a/band/band_au915_928_test.go
+++ b/band/band_au915_928_test.go
@@ -27,7 +27,7 @@ func TestAU915Band(t *testing.T) {
 		})
 
 		Convey("Then GetDownlinkTXPower returns the expected value", func() {
-			So(band.GetDownlinkTXPower(0), ShouldEqual, 20)
+			So(band.GetDownlinkTXPower(0), ShouldEqual, 27)
 		})
 
 		Convey("Then GetPingSlotFrequency returns the expected value", func() {


### PR DESCRIPTION
AU915 has a maximum EIRP of 30 dBm and the RF chain on AU915 gateways allows for a TX Power of 27 dBm, rather than the current limit of 20 dBm.

This should allow for more range and a better signal, especially with devices using the sx1262 radio, which is capable of transmitting at 22 dBm, and is therefore creating an asymmetrical link with ADR when the gateway is limited to 20 dBm. We've been seeing this a bit in our current testing, the gateway can hear the node, but the node can't hear responses reliably at default installation margin settings.

It's probably better that this asymmetry is in the other direction, as the ADR is based off how the gateway hears, rather than how the node hears.