### PR TITLE
Support custom HTTP authorization for roaming

### DIFF
--- a/backend/client_test.go
+++ b/backend/client_test.go
@@ -446,7 +446,7 @@ func TestSyncClient(t *testing.T) {
 	suite.Run(t, new(SyncClientTestSuite))
 }
 
-type AysncClientTestSuite struct {
+type AsyncClientTestSuite struct {
 	suite.Suite
 
 	client      Client
@@ -457,7 +457,7 @@ type AysncClientTestSuite struct {
 	apiResponse string
 }
 
-func (ts *AysncClientTestSuite) SetupSuite() {
+func (ts *AsyncClientTestSuite) SetupSuite() {
 	assert := require.New(ts.T())
 	var err error
 
@@ -478,11 +478,11 @@ func (ts *AysncClientTestSuite) SetupSuite() {
 	assert.NoError(err)
 }
 
-func (ts *AysncClientTestSuite) TearDownSuite() {
+func (ts *AsyncClientTestSuite) TearDownSuite() {
 	ts.redisClient.Close()
 }
 
-func (ts *AysncClientTestSuite) TestRequestTimeout() {
+func (ts *AsyncClientTestSuite) TestRequestTimeout() {
 	assert := require.New(ts.T())
 
 	req := PRStartReqPayload{
@@ -499,7 +499,7 @@ func (ts *AysncClientTestSuite) TestRequestTimeout() {
 	assert.Equal(ErrAsyncTimeout, errors.Cause(err))
 }
 
-func (ts *AysncClientTestSuite) TestWrongTransactionID() {
+func (ts *AsyncClientTestSuite) TestWrongTransactionID() {
 	assert := require.New(ts.T())
 
 	req := PRStartReqPayload{
@@ -536,7 +536,7 @@ func (ts *AysncClientTestSuite) TestWrongTransactionID() {
 	assert.Equal(ErrAsyncTimeout, errors.Cause(err))
 }
 
-func (ts *AysncClientTestSuite) TestJoinReq() {
+func (ts *AsyncClientTestSuite) TestJoinReq() {
 	assert := require.New(ts.T())
 
 	req := JoinReqPayload{
@@ -574,7 +574,7 @@ func (ts *AysncClientTestSuite) TestJoinReq() {
 	assert.Equal(ans, resp)
 }
 
-func (ts *AysncClientTestSuite) TestRejoinReq() {
+func (ts *AsyncClientTestSuite) TestRejoinReq() {
 	assert := require.New(ts.T())
 
 	req := RejoinReqPayload{
@@ -612,7 +612,7 @@ func (ts *AysncClientTestSuite) TestRejoinReq() {
 	assert.Equal(ans, resp)
 }
 
-func (ts *AysncClientTestSuite) TestPRStartReq() {
+func (ts *AsyncClientTestSuite) TestPRStartReq() {
 	assert := require.New(ts.T())
 
 	req := PRStartReqPayload{
@@ -650,7 +650,7 @@ func (ts *AysncClientTestSuite) TestPRStartReq() {
 	assert.Equal(ans, resp)
 }
 
-func (ts *AysncClientTestSuite) TestPRStopReq() {
+func (ts *AsyncClientTestSuite) TestPRStopReq() {
 	assert := require.New(ts.T())
 
 	req := PRStopReqPayload{
@@ -688,7 +688,7 @@ func (ts *AysncClientTestSuite) TestPRStopReq() {
 	assert.Equal(ans, resp)
 }
 
-func (ts *AysncClientTestSuite) TestXmitDataReq() {
+func (ts *AsyncClientTestSuite) TestXmitDataReq() {
 	assert := require.New(ts.T())
 
 	req := XmitDataReqPayload{
@@ -726,7 +726,7 @@ func (ts *AysncClientTestSuite) TestXmitDataReq() {
 	assert.Equal(ans, resp)
 }
 
-func (ts *AysncClientTestSuite) TestProfileReq() {
+func (ts *AsyncClientTestSuite) TestProfileReq() {
 	assert := require.New(ts.T())
 
 	req := ProfileReqPayload{
@@ -764,7 +764,7 @@ func (ts *AysncClientTestSuite) TestProfileReq() {
 	assert.Equal(ans, resp)
 }
 
-func (ts *AysncClientTestSuite) TestHomeNSReq() {
+func (ts *AsyncClientTestSuite) TestHomeNSReq() {
 	assert := require.New(ts.T())
 
 	req := HomeNSReqPayload{
@@ -802,7 +802,7 @@ func (ts *AysncClientTestSuite) TestHomeNSReq() {
 	assert.Equal(ans, resp)
 }
 
-func (ts *AysncClientTestSuite) TestSendAnswer() {
+func (ts *AsyncClientTestSuite) TestSendAnswer() {
 	assert := require.New(ts.T())
 
 	ans := HomeNSAnsPayload{
@@ -827,7 +827,7 @@ func (ts *AysncClientTestSuite) TestSendAnswer() {
 	assert.Equal(string(ansB), ts.apiRequest)
 }
 
-func (ts *AysncClientTestSuite) apiHandler(w http.ResponseWriter, r *http.Request) {
+func (ts *AsyncClientTestSuite) apiHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Header.Get("Authorization") != "Key secret" {
 		w.WriteHeader(http.StatusUnauthorized)
 		return
@@ -842,6 +842,6 @@ func (ts *AysncClientTestSuite) apiHandler(w http.ResponseWriter, r *http.Reques
 	w.Write([]byte(ts.apiResponse))
 }
 
-func TestAysncClient(t *testing.T) {
-	suite.Run(t, new(AysncClientTestSuite))
+func TestAsyncClient(t *testing.T) {
+	suite.Run(t, new(AsyncClientTestSuite))
 }

--- a/backend/client_test.go
+++ b/backend/client_test.go
@@ -31,9 +31,10 @@ func (ts *SyncClientTestSuite) SetupSuite() {
 	var err error
 	ts.server = httptest.NewServer(http.HandlerFunc(ts.apiHandler))
 	ts.client, err = NewClient(ClientConfig{
-		SenderID:   "010101",
-		ReceiverID: "020202",
-		Server:     ts.server.URL,
+		SenderID:      "010101",
+		ReceiverID:    "020202",
+		Server:        ts.server.URL,
+		Authorization: "Key secret",
 	})
 	assert.NoError(err)
 }
@@ -427,6 +428,11 @@ func (ts *SyncClientTestSuite) TestHomeNSReq() {
 }
 
 func (ts *SyncClientTestSuite) apiHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("Authorization") != "Key secret" {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
 	b, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		panic(err)
@@ -462,11 +468,12 @@ func (ts *AysncClientTestSuite) SetupSuite() {
 
 	ts.server = httptest.NewServer(http.HandlerFunc(ts.apiHandler))
 	ts.client, err = NewClient(ClientConfig{
-		SenderID:     "010101",
-		ReceiverID:   "020202",
-		Server:       ts.server.URL,
-		RedisClient:  ts.redisClient,
-		AsyncTimeout: time.Millisecond * 100,
+		SenderID:      "010101",
+		ReceiverID:    "020202",
+		Server:        ts.server.URL,
+		Authorization: "Key secret",
+		RedisClient:   ts.redisClient,
+		AsyncTimeout:  time.Millisecond * 100,
 	})
 	assert.NoError(err)
 }
@@ -821,6 +828,11 @@ func (ts *AysncClientTestSuite) TestSendAnswer() {
 }
 
 func (ts *AysncClientTestSuite) apiHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("Authorization") != "Key secret" {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
 	b, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		panic(err)

--- a/go.sum
+++ b/go.sum
@@ -21,7 +21,6 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20190328170749-bb2674552d8f h1:4Gslotqbs16iAg+1KR/XdabIfq8TlAWHdwS5QJFksLc=
 github.com/gopherjs/gopherjs v0.0.0-20190328170749-bb2674552d8f/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -61,7 +60,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v0.0.0-20190401211740-f487f9de1cd3 h1:hBSHahWMEgzwRyS6dRpxY0XyjZsHyQ61s084wo5PJe0=
 github.com/smartystreets/assertions v0.0.0-20190401211740-f487f9de1cd3/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
@@ -86,7 +84,6 @@ golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 h1:DYfZAGf2WMFjMxbgTjaC+2HC7NkNAQs+6Q8b9WEB/F4=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -104,7 +101,6 @@ google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miE
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Here's a small addition to the roaming client to support a custom value for the `Authorization` header.

This is used in Packet Broker and Actility ThingPark Exchange.