### PR TITLE
Update US902-928 to right Downlink MinDR according to RP2-1.0.3

### DIFF
--- a/band/band_us902_928.go
+++ b/band/band_us902_928.go
@@ -494,7 +494,7 @@ func newUS902Band(repeaterCompatible bool) (Band, error) {
 	for i := uint32(0); i < 8; i++ {
 		b.downlinkChannels[i] = Channel{
 			Frequency: 923300000 + (i * 600000),
-			MinDR:     10,
+			MinDR:     8,
 			MaxDR:     13,
 			enabled:   true,
 		}


### PR DESCRIPTION
RP2-1.0.3 defines that the MinDR for US902-928 is 8 (SF12BW500) not 10 (SF10BW500)