### PR TITLE
Avoid panic on invalid NetID type

### DIFF
--- a/fhdr.go
+++ b/fhdr.go
@@ -19,7 +19,8 @@ func (a DevAddr) NetIDType() int {
 			return 7 - i
 		}
 	}
-	panic("NetIDType bug!")
+
+	return -1
 }
 
 // NwkID returns the NwkID bits of the DevAddr.


### PR DESCRIPTION
We were seeing infrequent crashes during logging of the NwkId, this was caused by this line. 